### PR TITLE
Enable zero-copy splice on linux

### DIFF
--- a/cdef/fcntl/linux.h
+++ b/cdef/fcntl/linux.h
@@ -1,4 +1,8 @@
+typedef long long loff_t;
+
 int fcntl(int fd, int cmd, ... /* arg */);
+ssize_t splice(int fd_in, loff_t *off_in, int fd_out,
+                      loff_t *off_out, size_t len, unsigned int flags);
 
 static const int F_DUPFD = 0; /* Duplicate file descriptor.  */
 static const int F_GETFD = 1; /* Get file descriptor flags.  */
@@ -20,3 +24,8 @@ static const int O_NDELAY = O_NONBLOCK;
 static const int O_SYNC =     04010000;
 static const int O_FSYNC =      O_SYNC;
 static const int O_ASYNC =      020000;
+
+static const int SPLICE_F_MOVE = 1;
+static const int SPLICE_F_NONBLOCK = 2;
+static const int SPLICE_F_MORE = 4;
+static const int SPLICE_F_GIFT = 8;

--- a/cdef/std/std.h
+++ b/cdef/std/std.h
@@ -4,6 +4,7 @@ void *realloc(void *ptr, size_t size);
 void free(void *);
 void memcpy(void *restrict, const void *restrict, size_t);
 void memmove(void *restrict, const void *restrict, size_t);
+int getpagesize(void);
 
 
 static const int STDIN = 0;


### PR DESCRIPTION
This adds zero-copy splice for Linux. (we should add BSDs when we get around to that). Currently, the zero-copy splice will only be used when at least 4 or more pages of memory are expected. If any data is pending in the read buffer, that will first be transferred using the single-copy splice. The remaining length is what must be 4 pages or greater.