### PR TITLE
Change status values to be an object

### DIFF
--- a/levee/p/http.lua
+++ b/levee/p/http.lua
@@ -30,6 +30,10 @@ function Status_mt:__tostring()
 end
 
 
+function Status_mt:no_content()
+	return self.code == 204 or self.code == 304
+end
+
 
 local Status = {}
 
@@ -731,7 +735,7 @@ function Server_mt:_response(response)
 	local err, value = response:recv()
 	if err then return err end
 	local status, headers, body = unpack(value)
-	local no_content = status.code == 304
+	local no_content = status:no_content()
 
 	local err = self.conn:send(tostring(status))
 	if err then return err end


### PR DESCRIPTION
This changes the status object to be a table with `code` and `reason` fields and a caching `tostring` metamethod. This should not incur any significant API changes, but simplifies sending the status reason as a body:

```lua
local status = levee.HTTPStatus(404)
req.response:send({status, {}, status.reason)
```

While this PR doesn't currently address this, I think the `levee.HTTPStatus` is an odd choice. It seems pretty arbitrary to have it a special top-level value in the `levee` namespace.
