### PR TITLE
Extract sendfile from http module

### DIFF
--- a/levee/_/syscalls.lua
+++ b/levee/_/syscalls.lua
@@ -214,6 +214,13 @@ _.reads = function(no, len)
 end
 
 
+_.sendfile = function(from, to, len, off)
+	local n = C.levee_sendfile(to, from, off or 0, len)
+	if n >= 0 then return nil, tonumber(n) end
+	return errors.get(ffi.errno())
+end
+
+
 if ffi.os:lower() == "linux" then
 	_.splice = function(from, to, len, more)
 		local flags = bit.bor(C.SPLICE_F_MOVE, C.SPLICE_F_NONBLOCK)


### PR DESCRIPTION
This adds a low-level `sendfile` to syscalls and a convenience wrapper
inside of the IO module. The `http` module now only handles status codes
and relays the call into IO.

This also exposes the use of offsets into the file being sent.