### PR TITLE
Add versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 * fix escaping strings for JSON encode
 * add a binding for getrusage
 * add an is_option convenience to \_.argv
+* add \_.version to parse semver strings
+* add -v/--version to restrict build
 
 
 ## 0.3.2 - 2016-02-24

--- a/levee/_/init.lua
+++ b/levee/_/init.lua
@@ -8,6 +8,7 @@ ret.template = require("levee._.template")
 ret.term = require("levee._.term")
 ret.bundle = require("levee._.bundle")
 ret.log = require("levee._.log")
+ret.version = require("levee._.version")
 
 for k, v in pairs(require("levee._.syscalls")) do ret[k] = v end
 for k, v in pairs(require("levee._.process")) do ret[k] = v end

--- a/levee/_/version.lua
+++ b/levee/_/version.lua
@@ -97,18 +97,17 @@ function Version_mt:_bump_major(val)
 end
 
 
-function Version_mt:bump(field)
+function Version_mt:bump(field, val)
 	local new = copy(self)
-	if field then
-		new["_bump_"..field](new)
-	else
+	if not field then
 		for i,key in ipairs{"pre_release", "patch", "minor", "major"} do
 			if new[key] then
-				new["_bump_"..key](new)
+				field = key
 				break
 			end
 		end
 	end
+	new["_bump_"..field](new, val)
 	return new
 end
 

--- a/levee/_/version.lua
+++ b/levee/_/version.lua
@@ -47,6 +47,7 @@ end
 function Version_mt:is_compatible(v)
 	if type(v) == "string" then
 		v = parse(v)
+		if not v then return false end
 	end
 	if self.pre_release_name ~= v.pre_release_name then
 		return false

--- a/levee/_/version.lua
+++ b/levee/_/version.lua
@@ -1,0 +1,87 @@
+local lpeg = require('lpeg')
+local P, R, S, Ct, Cg = lpeg.P, lpeg.R, lpeg.S, lpeg.Ct, lpeg.Cg
+
+local num = (S("0123456789xX")^0)/tonumber
+local id = (R("az","AZ","09")^0)/tostring
+local pre = P("-") * Cg(id, "pre_release_name") * ("." * Cg(num, "pre_release_version"))^-1
+local ver =
+	Ct(P("v")^-1
+	* Cg(num, "major")
+		* ("." * Cg(num, "minor")
+			* ("." * Cg(num, "patch")
+				* pre^-1)^-1)^-1) * P(-1)
+
+
+local Version_mt = {}
+Version_mt.__index = Version_mt
+
+
+local function make(t)
+	if t.pre_release_name and not t.pre_release then
+		t.pre_release = ("-%s.%s"):format(
+			t.pre_release_name,
+			t.pre_release_version or "x")
+	end
+	return setmetatable(t, Version_mt)
+end
+
+
+local function copy(v)
+	return make({
+		major = v.major,
+		minor = v.minor,
+		patch = v.patch,
+		pre_release = v.pre_release,
+		pre_release_name = v.pre_release_name,
+		pre_release_version = v.pre_release_version
+	})
+end
+
+
+local function parse(v)
+	local t = ver:match(v)
+	if t then return make(t) end
+end
+
+
+function Version_mt:is_compatible(v)
+	if type(v) == "string" then
+		v = parse(v)
+	end
+	if self.pre_release_name ~= v.pre_release_name then
+		return false
+	end
+	for i,key in ipairs{"pre_release_version", "patch", "minor", "major"} do
+		if v[key] and self[key] ~= v[key] then
+			return false
+		end
+	end
+	return true
+end
+
+
+function Version_mt:__eq(other)
+	return self.major == other.major
+		and self.minor == other.minor
+		and self.patch == other.patch
+		and self.pre_release_name == other.pre_release_name
+		and self.pre_release_version == other.pre_release_version
+end
+
+
+function Version_mt:__tostring()
+	return ("v%s.%s.%s%s"):format(
+		self.major or "x",
+		self.minor or "x",
+		self.patch or "x",
+		self.pre_release or "")
+end
+
+
+return function(v)
+	local out
+	if type(v) == "table" then
+	elseif type(v) == "string" then
+		return parse(v)
+	end
+end

--- a/levee/_/version.lua
+++ b/levee/_/version.lua
@@ -133,6 +133,7 @@ end
 return function(v)
 	local out
 	if type(v) == "table" then
+		return copy(v)
 	elseif type(v) == "string" then
 		return parse(v)
 	end

--- a/levee/cmd/build.lua
+++ b/levee/cmd/build.lua
@@ -108,6 +108,9 @@ Options:
 
 			elseif opt == "n" or opt == "name" then
 				options.name = argv:next()
+
+			elseif opt == "v" or opt == "version" then
+				options.version = argv:next()
 			end
 		end
 
@@ -129,6 +132,20 @@ Options:
 
 			if st:is_reg() then
 				options.file = options.modules[1]
+			end
+		end
+
+
+		if options.version then
+			local v = _.version(options.version)
+			if not v then
+				io.stderr:write("invalid version string\n")
+				os.exit(1)
+			end
+
+			if not meta.version:is_compatible(v) then
+				io.stderr:write("required version is not compatible\n")
+				os.exit(1)
 			end
 		end
 

--- a/levee/cmd/version.lua
+++ b/levee/cmd/version.lua
@@ -33,20 +33,12 @@ Options:
 
 	run = function(options)
 		local version = meta.version
-		if options.build then
-			print(string.format("%d.%d.%d%s",
-				version.major, version.minor, version.patch, version.pre_release))
-		end
-		if options.date then
-			print(version.date.string)
-		end
+		if options.build then print(version.string) end
+		if options.date then print(version.date.string) end
 		if not options.build and not options.date then
-			print(string.format("%s version %d.%d.%d%s %s",
+			print(string.format("%s version %s %s",
 				capitalize(meta.name),
-				version.major,
-				version.minor,
-				version.patch,
-				version.pre_release,
+				version,
 				version.date.string))
 			print(string.format("Copyright (c) %d Imgix",
 				version.date.year))

--- a/levee/meta.lua
+++ b/levee/meta.lua
@@ -1,3 +1,5 @@
+local Version = require("levee._.version")
+
 local date = {
 	year = 2016,
 	month = 2,
@@ -9,16 +11,16 @@ date.string = string.format(
 	date.year, date.month, date.day
 )
 
-local version = {
+local version = Version{
 	major = 0,
 	minor = 3,
 	patch = 3,
-	pre_release = "-alpha",
-	date = date, }
+	pre_release_name = "alpha",
+	pre_release_version = 1,
+}
 
-version.string = string.format(
-	"%d.%d.%d%s",
-	version.major, version.minor, version.patch, version.pre_release)
+version.date = date
+version.string = tostring(version)
 
 return {
 	name = "levee",

--- a/tests/_/test_version.lua
+++ b/tests/_/test_version.lua
@@ -45,4 +45,22 @@ return {
 		assert.same("v1.2.3-beta.x", tostring(_.version("v1.2.3-beta.x")))
 		assert.same("v1.2.3-beta.1", tostring(_.version("v1.2.3-beta.1")))
 	end,
+
+	test_bump = function()
+		local v = _.version("v1.2.3")
+		assert.same("v1.2.4-alpha.1", tostring(v:bump("pre_release")))
+		assert.same("v1.2.4", tostring(v:bump("patch")))
+		assert.same("v1.3.0", tostring(v:bump("minor")))
+		assert.same("v2.0.0", tostring(v:bump("major")))
+		assert.same("v1.2.4", tostring(v:bump()))
+	end,
+
+	test_bump_pre_release = function()
+		local v = _.version("v1.2.3-foo.4")
+		assert.same("v1.2.3-foo.5", tostring(v:bump("pre_release")))
+		assert.same("v1.2.4", tostring(v:bump("patch")))
+		assert.same("v1.3.0", tostring(v:bump("minor")))
+		assert.same("v2.0.0", tostring(v:bump("major")))
+		assert.same("v1.2.3-foo.5", tostring(v:bump()))
+	end
 }

--- a/tests/_/test_version.lua
+++ b/tests/_/test_version.lua
@@ -1,0 +1,48 @@
+local _ = require("levee")._
+
+
+return {
+	test_basic = function()
+		local base = _.version("v1.2.9")
+		assert(base ~= nil)
+		assert(base:is_compatible("v1.x"))
+		assert(base:is_compatible("v1.2"))
+		assert(base:is_compatible("v1.2.x"))
+		assert(base:is_compatible("v1.2.9"))
+		assert(not base:is_compatible("v1.2.8"))
+		assert(not base:is_compatible("v1.3.9"))
+		assert(not base:is_compatible("v1.3.x"))
+	end,
+
+	test_beta = function()
+		local beta = _.version("v1.3.0-beta.1")
+		assert(beta ~= nil)
+		assert(beta:is_compatible("v1.3.0-beta"))
+		assert(beta:is_compatible("v1.3.0-beta.x"))
+		assert(beta:is_compatible("v1.3.0-beta.1"))
+		assert(not beta:is_compatible("v1.3.0-beta.2"))
+		assert(not beta:is_compatible("v1.3.1-beta.1"))
+		assert(not beta:is_compatible("v1.3.0"))
+	end,
+
+	test_string = function()
+		assert.same("v1.x.x", tostring(_.version("1")))
+		assert.same("v1.x.x", tostring(_.version("1.x")))
+		assert.same("v1.x.x", tostring(_.version("1.x.x")))
+		assert.same("v1.2.x", tostring(_.version("1.2")))
+		assert.same("v1.2.x", tostring(_.version("1.2.x")))
+		assert.same("v1.2.3", tostring(_.version("1.2.3")))
+		assert.same("v1.2.3-beta.x", tostring(_.version("1.2.3-beta")))
+		assert.same("v1.2.3-beta.x", tostring(_.version("1.2.3-beta.x")))
+		assert.same("v1.2.3-beta.1", tostring(_.version("1.2.3-beta.1")))
+		assert.same("v1.x.x", tostring(_.version("v1")))
+		assert.same("v1.x.x", tostring(_.version("v1.x")))
+		assert.same("v1.x.x", tostring(_.version("v1.x.x")))
+		assert.same("v1.2.x", tostring(_.version("v1.2")))
+		assert.same("v1.2.x", tostring(_.version("v1.2.x")))
+		assert.same("v1.2.3", tostring(_.version("v1.2.3")))
+		assert.same("v1.2.3-beta.x", tostring(_.version("v1.2.3-beta")))
+		assert.same("v1.2.3-beta.x", tostring(_.version("v1.2.3-beta.x")))
+		assert.same("v1.2.3-beta.1", tostring(_.version("v1.2.3-beta.1")))
+	end,
+}


### PR DESCRIPTION
Primarily, this adds a `-v/--version` option to the build command to ensure an expected version of levee that is building a project:

```bash
levee build --version 0.3.3-alpha.1 ... # only build with alpha1
levee build --version 0.3.3 ... # build with 0.3.3 release only
levee build --version 0.3.x ... # build with any 0.3 non-pre-release versions
```

This adds in an `_.version` function that can parse semantic version strings. This value can them be compared and bumped.