### PR TITLE
Refactor iovec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * fix timeout when recv-ing from a thread channel
 * wrap main event loop with an xpcall to capture a traceback if it should
   unexpectedly crash
+* refactor iovec
 
 ## 0.3.2 - 2016-02-24
 

--- a/levee/core/io.lua
+++ b/levee/core/io.lua
@@ -3,6 +3,7 @@ local C = ffi.C
 
 local message = require("levee.core.message")
 local errors = require("levee.errors")
+local Iovec = require("levee.d.iovec")
 
 local _ = require("levee._")
 local d = require("levee.d")
@@ -10,55 +11,6 @@ local p = require("levee.p")
 
 
 local MIN_SPLICE_SIZE = 4 * _.pagesize
-
-
---
--- Iovec
-
-local iovec = ffi.typeof("struct iovec[?]")
-
-
-local Iovec_mt = {}
-Iovec_mt.__index = Iovec_mt
-
-
-function Iovec_mt:write(buf, len)
-	assert(self.n < self.size)
-
-	if not len then
-		len = #buf
-	end
-
-	if len == 0 then
-		return nil, 0
-	end
-
-	if type(buf) == "string" then
-		buf = ffi.cast("char*", buf)
-	end
-
-	self.iov[self.n].iov_base = buf
-	self.iov[self.n].iov_len = len
-
-	self.len = self.len + len
-	self.n = self.n + 1
-end
-
-
-function Iovec_mt:reset()
-	self.n = 0
-	self.len = 0
-end
-
-
-local function Iovec(size)
-	local self = setmetatable({
-		iov = iovec(size),
-		n = 0,
-		len = 0,
-		size = size, }, Iovec_mt)
-	return self
-end
 
 
 --
@@ -313,15 +265,10 @@ function W_mt:iov(size)
 
 				local num = #q
 				for s in q:iter() do
-					-- TODO - eep
-					if s.value then
-						iov:write(s:value())
-					else
-						iov:write(s)
-					end
+					iov:write(s)
 				end
 
-				local err, n = self:writev(iov.iov, iov.n)
+				local err, n = self:writev(iov:value())
 				if err then
 					q.fifo:remove(#q.fifo)   -- this should be handled in stalk
 					self:close()

--- a/levee/core/io.lua
+++ b/levee/core/io.lua
@@ -3,7 +3,6 @@ local C = ffi.C
 
 local message = require("levee.core.message")
 local errors = require("levee.errors")
-local Iovec = require("levee.d.iovec")
 
 local _ = require("levee._")
 local d = require("levee.d")
@@ -257,7 +256,7 @@ function W_mt:iov(size)
 		self.empty = q.empty
 
 		self.hub:spawn(function()
-			local iov = Iovec(size)
+			local iov = d.Iovec(size)
 
 			while true do
 				local err = q:recv()
@@ -905,7 +904,7 @@ function IO_mt:open(name, ...)
 end
 
 
-IO_mt.iovec = Iovec
+IO_mt.iovec = d.Iovec
 IO_mt.R_mt = R_mt
 
 

--- a/levee/d/buffer.lua
+++ b/levee/d/buffer.lua
@@ -190,6 +190,11 @@ function Buffer_mt:push(s)
 end
 
 
+function Buffer_mt:writeinto_iovec(iov)
+	iov:writeraw(self:value())
+end
+
+
 local function cleanup(buf)
 	C.free(buf.buf)
 	C.free(buf)

--- a/levee/d/init.lua
+++ b/levee/d/init.lua
@@ -1,5 +1,6 @@
 return {
 	Buffer = require("levee.d.buffer"),
+	Iovec = require("levee.d.iovec"),
 	Data = require("levee.d.data"),
 	Fifo = require("levee.d.fifo"),
 	Heap = require("levee.d.heap").Heap,

--- a/levee/d/iovec.lua
+++ b/levee/d/iovec.lua
@@ -1,0 +1,125 @@
+local ffi = require('ffi')
+local C = ffi.C
+
+local errors = require("levee.errors")
+
+
+local iovec_size = ffi.sizeof("struct iovec")
+local iovecp = ffi.typeof("struct iovec *")
+
+
+local Iovec_mt = {}
+Iovec_mt.__index = Iovec_mt
+
+
+function Iovec_mt:__tostring()
+	return string.format(
+		"levee.d.Iovec: n=%u, len=%u, size=%u",
+		self.n, self.len, self.size)
+end
+
+
+function Iovec_mt:__len()
+	return self.len
+end
+
+
+function Iovec_mt:write(val, len)
+	if type(val) == "cdata" or val.writeinto_iovec then
+		val:writeinto_iovec(self)
+		return
+	end
+
+	if val.value then
+		val, len = val:value()
+	end
+
+	self:writeraw(val, len)
+end
+
+
+function Iovec_mt:writeraw(val, len)
+	if self.n == self.size then
+		self:ensure(1)
+	end
+
+	if self.n == self.size then
+		self:ensure(1)
+	end
+
+	if not len then
+		len = #val
+	end
+
+	if len == 0 then
+		return
+	end
+
+	if type(val) == "string" then
+		val = ffi.cast("char *", val)
+	end
+
+	self.iov[self.n].iov_base = val
+	self.iov[self.n].iov_len = len
+
+	self.len = self.len + len
+	self.n = self.n + 1
+end
+
+
+function Iovec_mt:writeinto_iovec(iov)
+	iov:ensure(self.n)
+	C.memcpy(self.iov + self.n, iov.iov, iovec_size * iov.n)
+	iov:bump(iov.n)
+end
+
+
+function Iovec_mt:ensure(n)
+	local size = self.n + n
+	if size <= self.size then return end
+	size = math.pow(2, math.ceil(math.log(tonumber(size))/math.log(2)))
+	local iov = ffi.cast(iovecp, C.malloc(iovec_size * size))
+	if iov == nil then error(tostring(errors.get(ffi.errno()))) end
+	C.memcpy(iov, self.iov, ffi.sizeof(iov[0]) * self.n)
+	self.iov = ffi.gc(iov, C.free)
+	self.size = size
+end
+
+
+function Iovec_mt:value()
+	return self.iov, self.n
+end
+
+
+function Iovec_mt:tail()
+	return self.iov + self.n, self.size - self.n
+end
+
+
+function Iovec_mt:bump(n, len)
+	if not len then
+		len = 0
+		for i=self.n,self.n+n-1 do
+			len = len + self.iov[i].iov_len
+		end
+	end
+	self.n = self.n + n
+	self.len = self.len + len
+end
+
+
+function Iovec_mt:reset()
+	self.n = 0
+	self.len = 0
+end
+
+
+return function(size)
+	local self = setmetatable({
+		iov = nil,
+		n = 0,
+		len = 0,
+		size = 0, }, Iovec_mt)
+	if size then self:ensure(size) end
+	return self
+end

--- a/levee/net/dialer.lua
+++ b/levee/net/dialer.lua
@@ -18,6 +18,11 @@ function Request_mt:value()
 end
 
 
+function Request_mt:writeinto_iovec(iov)
+	iov:writeraw(self:value())
+end
+
+
 function Request_mt:__len()
 	return ffi.sizeof(self)
 end

--- a/levee/net/dialer.lua
+++ b/levee/net/dialer.lua
@@ -32,6 +32,25 @@ local Request = ffi.metatype("struct LeveeDialerRequest", Request_mt)
 
 
 --
+-- Message
+
+local Message_mt = {}
+Message_mt.__index = Message_mt
+
+
+function Message_mt:writeinto_iovec(iov)
+	iov:write(self[1])
+	iov:write(self[2])
+	iov:write(self[3])
+end
+
+
+local function Message(req, node, service)
+	return setmetatable({ req, node, service }, Message_mt)
+end
+
+
+--
 -- Dialer
 
 local Dialer_mt = {}
@@ -47,9 +66,7 @@ function Dialer_mt:__dial(family, socktype, node, service)
 	self.req.node_len = #node
 	self.req.service_len = #service
 
-	self.sender:send(self.req)
-	self.sender:send(node)
-	self.sender:send(service)
+	self.sender:send(Message(self.req, node, service))
 
 	self.recver:read(self.res)
 

--- a/tests/d/test_iovec.lua
+++ b/tests/d/test_iovec.lua
@@ -1,0 +1,99 @@
+local ffi = require("ffi")
+local Iovec = require("levee").d.Iovec
+
+
+return {
+	test_core = function()
+		local iov = Iovec()
+		local cdata, valuen, tailn, oldtailn
+
+		assert.equal(#iov, 0)
+
+		cdata, valuen = iov:value()
+		assert.equal(valuen, 0)
+
+		iov:ensure(4)
+
+		cdata, valuen = iov:value()
+		assert.equal(valuen, 0)
+		assert.equal(#iov, 0)
+
+		cdata, tailn = iov:tail()
+		assert(tailn >= 4)
+		assert.equal(#iov, 0)
+		oldtailn = tailn
+
+		iov:write("test")
+
+		cdata, valuen = iov:value()
+		assert.equal(valuen, 1)
+		assert.equal(#iov, 4)
+
+		cdata, tailn = iov:tail()
+		assert.equal(tailn, oldtailn-1)
+	end,
+
+	test_manual = function()
+		local iov = Iovec()
+		iov:ensure(4)
+
+		assert.equal(#iov, 0)
+
+		local i, n = iov:tail()
+		i[0].iov_base = ffi.cast("char *", "test")
+		i[0].iov_len = 4
+		i[1].iov_base = ffi.cast("char *", "value")
+		i[1].iov_len = 5
+		i[2].iov_len = 999 -- overwrite to check bump logic
+
+		iov:bump(2) -- have bump calculate the new length
+
+		assert.equal(#iov, 9)
+
+		local i, n = iov:tail()
+		i[0].iov_base = ffi.cast("char *", "stuff")
+		i[0].iov_len = 5
+		i[1].iov_len = 999 -- overwrite to check bump logic
+
+		iov:bump(1, 5) -- manually bump the length
+
+		assert.equal(#iov, 14)
+
+		local i, n = iov:value()
+		assert.equal(n, 3)
+		assert.equal(ffi.string(i[0].iov_base, i[0].iov_len), "test")
+		assert.equal(ffi.string(i[1].iov_base, i[1].iov_len), "value")
+		assert.equal(ffi.string(i[2].iov_base, i[2].iov_len), "stuff")
+	end,
+
+	test_writeinto = function()
+		ffi.cdef[[
+		struct Person {
+			char *first, *last;
+		};
+		size_t strlen(const char *s);
+		]]
+
+		local Person_mt = {}
+		Person_mt.__index = Person_mt
+
+		local space = " "
+
+		function Person_mt:writeinto_iovec(iov)
+			iov:writeraw(self.first, ffi.C.strlen(self.first))
+			iov:write(space)
+			iov:writeraw(self.last, ffi.C.strlen(self.last))
+		end
+
+		local Person = ffi.metatype("struct Person", Person_mt)
+
+		local andy = Person()
+		andy.first = ffi.cast("char *", "Andy")
+		andy.last = ffi.cast("char *", "Gayton")
+
+		local iov = Iovec()
+		iov:write(andy)
+
+		assert.equal(#iov, 11)
+	end,
+}


### PR DESCRIPTION
This sets a contract for working with iovec arrays. All `cdata` types that will be written through the `IO` module must implement `:writeinto_iovec(iov)`. Lua objects may optionally implement `:writeinto_iovec(iov)` or `:value() -> buf, len`.