### PR TITLE
dialer returns EAI_NODATA if dns returns zero results

### DIFF
--- a/levee/net/dialer.lua
+++ b/levee/net/dialer.lua
@@ -145,7 +145,7 @@ function Dialer_mt:__dial_async(family, socktype, node, service, timeout)
 		local err, records = self.hub.dns:resolve(node, qtype)
 		if err then return err end
 		if #records == 0 then
-			return errors.addr.ENONAME
+			return errors.addr.ENODATA
 		end
 
 		nodes = {}

--- a/tests/net/test_dialer.lua
+++ b/tests/net/test_dialer.lua
@@ -27,9 +27,11 @@ __test_core = function(async)
 	assert(not conn)
 
 	local err, conn = h.dialer:dial(C.AF_INET, C.SOCK_STREAM, "kdkd", port, nil, async)
-	local want = errors.addr.ENONAME
-	if async then want = errors.dns.NXDOMAIN end
-	assert.equal(err, want)
+	if async then
+		assert.contains(err, {errors.dns.NXDOMAIN, errors.addr.ENODATA})
+	else
+		assert.equal(err, errors.addr.ENONAME)
+	end
 
 	-- timeout
 	local err, conn = h.dialer:dial(C.AF_INET, C.SOCK_STREAM, "10.244.245.246", port, 20, async)


### PR DESCRIPTION
non-exisiting dns record test expects either EAI_NODATA or NXDOMAIN